### PR TITLE
Add ugly patch to allow values from a range given by AWS

### DIFF
--- a/boto/rds/parametergroup.py
+++ b/boto/rds/parametergroup.py
@@ -137,8 +137,8 @@ class Parameter(object):
             raise ValueError('value must be of type str')
         if self.allowed_values:
             choices = self.allowed_values.split(',')
-            if value not in choices:
-                raise ValueError('value must be in %s' % self.allowed_values)
+            if value not in choices and len(choices) > 1:
+                raise ValueError('value "%s" must be in %s' % (value,self.allowed_values))
         self._value = value
 
     def _set_integer_value(self, value):


### PR DESCRIPTION
As background, the 'allowed_values' field is normally a list, i.e.
['a','b','c'] or [1,2,3]. However updates to AWS changed this to also
permit a range of values (particularly for floats/ints). This means that
you may receive a 'allowed_values' field of: ['0-1000']. The logic that
checks whether 'my_value' in ['0-1000'] will always fail, because you
would have to literally pass '0-1000' instead of your desired value.

While the true solution here is to actually put in logic to locate this
case and check whether your value falls within the range given, instead
this patch just says that if there is only one option (likely to only
occur in this type of case) we'll just allow you to set the value, at
which point the API itself will error if you didn't follow the
guidelines of the API.